### PR TITLE
Time extension

### DIFF
--- a/.env-default
+++ b/.env-default
@@ -1,7 +1,0 @@
-# For new installations, modify this file as appropriate for
-# your environment and rename it as '.env'.
-
-USER_ID=1000             # adjust uid with a local account uid
-GROUP_ID=1000            # adjust gid with a local account gid
-
-VOLUME_PATH=./volumes

--- a/.env-default
+++ b/.env-default
@@ -1,0 +1,7 @@
+# For new installations, modify this file as appropriate for
+# your environment and rename it as '.env'.
+
+USER_ID=1000             # adjust uid with a local account uid
+GROUP_ID=1000            # adjust gid with a local account gid
+
+VOLUME_PATH=./volumes

--- a/oregoninvasiveshotline/users/models.py
+++ b/oregoninvasiveshotline/users/models.py
@@ -44,7 +44,7 @@ class User(AbstractBaseUser):
     def from_signature(cls, signature):
         try:
             signer = TimestampSigner()
-            value = signer.unsign(signature, max_age=60 * 60 * 24)
+            value = signer.unsign(signature, max_age=60 * 60 * 24 * 7)
             return cls.objects.get(email=value)
         except SignatureExpired:
             return None


### PR DESCRIPTION
# Invite an Expert Email Timer Extension
Time limit on email links sent from the hotline has been extended from 1 day to 7 days. This affects all such timers in the hotline.